### PR TITLE
Updating ads-ioc to R0.8.0

### DIFF
--- a/lcls-plc-crixs-motion/iocBoot/ioc-PLC-CRIX-MOT/Makefile
+++ b/lcls-plc-crixs-motion/iocBoot/ioc-PLC-CRIX-MOT/Makefile
@@ -1,4 +1,4 @@
-IOC_TOP=/reg/g/pcds/epics/ioc/common/ads-ioc/R0.6.1
+IOC_TOP=/reg/g/pcds/epics/ioc/common/ads-ioc/R0.8.0
 IOC_INSTANCE_PATH := $(shell pwd)
 
 # Set PRODUCTION_IOC to 1 to move from a testing to a production IOC:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
As part of ECS-773.
This uses a new version of the ads module which will automatically reboot the ioc upon a bulk-read failure, an error state that requires a restart to fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to fixed versions and not ``Always Newest``
- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)
